### PR TITLE
Fix Retry Policies Retry Less Times Than Specified

### DIFF
--- a/src/Policy/Retry/MaxAttemptsRetryPolicy.php
+++ b/src/Policy/Retry/MaxAttemptsRetryPolicy.php
@@ -49,6 +49,6 @@ class MaxAttemptsRetryPolicy implements RetryPolicy
      */
     public function shouldRetry(Exception $e, RetryContext $context): bool
     {
-        return $context->getRetryCount() < $this->maxAttempts;
+        return $context->getRetryCount() <= $this->maxAttempts;
     }
 }

--- a/src/Policy/Retry/SimpleRetryPolicy.php
+++ b/src/Policy/Retry/SimpleRetryPolicy.php
@@ -50,7 +50,7 @@ class SimpleRetryPolicy implements RetryPolicy
      */
     public function shouldRetry(Exception $e, RetryContext $context): bool
     {
-        if ($context->getRetryCount() >= $this->maxAttempts) {
+        if ($context->getRetryCount() > $this->maxAttempts) {
             return false;
         }
 

--- a/tests/Policy/Retry/MaxAttemptsRetryPolicyTest.php
+++ b/tests/Policy/Retry/MaxAttemptsRetryPolicyTest.php
@@ -14,7 +14,7 @@ class MaxAttemptsRetryPolicyTest extends TestCase
         $exception = new Exception();
 
         $retryContext = $this->createMock(RetryContext::class);
-        $retryContext->method('getRetryCount')->willReturnOnConsecutiveCalls(0, 1, 2, 3, 4);
+        $retryContext->method('getRetryCount')->willReturnOnConsecutiveCalls(1, 2, 3, 4, 5);
 
         $maxAttempts = 3;
         $retryPolicy = new MaxAttemptsRetryPolicy($maxAttempts);

--- a/tests/Policy/Retry/SimpleRetryPolicyTest.php
+++ b/tests/Policy/Retry/SimpleRetryPolicyTest.php
@@ -16,11 +16,12 @@ class SimpleRetryPolicyTest extends TestCase
         $exception2 = new RuntimeException("Exception 2");
 
         $context = $this->createMock(RetryContext::class);
-        $context->method('getRetryCount')->willReturnOnConsecutiveCalls(1, 2, 3, 4, 5);
+        $context->method('getRetryCount')->willReturnOnConsecutiveCalls(1, 2, 3, 4, 5, 6);
 
         $retryPolicy = new SimpleRetryPolicy(3, [Exception::class]);
 
         // Retry is allowed when the number of attempts is less than maxAttempts and the exception is in the list of retryable exceptions
+        $this->assertTrue($retryPolicy->shouldRetry($exception1, $context));
         $this->assertTrue($retryPolicy->shouldRetry($exception1, $context));
         $this->assertTrue($retryPolicy->shouldRetry($exception1, $context));
 
@@ -39,7 +40,7 @@ class SimpleRetryPolicyTest extends TestCase
     {
         $exception = new Exception();
         $context = $this->createMock(RetryContext::class);
-        $context->method('getRetryCount')->willReturnOnConsecutiveCalls(0, 1, 2, 3);
+        $context->method('getRetryCount')->willReturnOnConsecutiveCalls(1, 2, 3, 4);
 
         $retryPolicy = new SimpleRetryPolicy();  // Use the default maxAttempts value
 


### PR DESCRIPTION
### Description of Changes

This PR addresses a bug in `MaxAttemptsRetryPolicy` and `SimpleRetryPolicy` where the action was being retried one less time than specified. The changes ensure that the number of retries matches the value set in the retry policy.

### Related Issue

This PR resolves the issue described here: #11 

### How Has This Been Tested?

The changes have been tested by:
1. Instantiating a `MaxAttemptsRetryPolicy` or `SimpleRetryPolicy` with a maximum attempts value of n.
2. Executing a failing operation wrapped in this retry policy.
3. Observing that the operation is retried n times, as expected.

In addition, existing unit tests have been adjusted to account for this change and all tests pass successfully.

### Checklist

- [x] I have tested my changes and corrected any errors.
- [x] I have documented my changes if necessary.
