### PR TITLE
Fix `NonRepeatingExceptionRetryPolicy` Never Retries

### DIFF
--- a/src/Context/RetryContext.php
+++ b/src/Context/RetryContext.php
@@ -21,10 +21,14 @@ class RetryContext
     private int $retryCount = 0;
 
     /**
-     * @var Exception|null The last exception that was thrown during a retry
-     *                     attempt.
+     * @var Exception[] The exceptions that were thrown during retry attempts.
      */
-    private ?Exception $lastException = null;
+    private array $exceptions = [];
+
+    /**
+     * @var int The number of exceptions that occurred during retry attempts.
+     */
+    private int $exceptionCount = 0;
 
     /**
      * @var float The time (in microseconds as a float) when the context
@@ -56,24 +60,34 @@ class RetryContext
     }
 
     /**
-     * Sets the last exception that was thrown during a retry attempt.
+     * Adds an exception to the list of exceptions thrown during retry attempts.
      *
-     * @param Exception $exception The exception to set as the last exception.
+     * @param Exception $exception The exception to add.
      */
-    public function setLastException(Exception $exception): void
+    public function addException(Exception $exception): void
     {
-        $this->lastException = $exception;
+        $this->exceptions[] = $exception;
+        $this->exceptionCount++;
     }
 
     /**
-     * Gets the last exception that was thrown during a retry attempt.
+     * Gets the exceptions that were thrown during retry attempts.
      *
-     * @return Exception|null The last exception, or null if no exception has
-     *                        been set yet.
+     * @return Exception[] The exceptions.
      */
-    public function getLastException(): ?Exception
+    public function getExceptions(): array
     {
-        return $this->lastException;
+        return $this->exceptions;
+    }
+
+    /**
+     * Gets the number of exceptions that occurred during retry attempts.
+     *
+     * @return int The exception count.
+     */
+    public function getExceptionCount(): int
+    {
+        return $this->exceptionCount;
     }
 
     /**

--- a/src/Policy/Retry/NonRepeatingExceptionRetryPolicy.php
+++ b/src/Policy/Retry/NonRepeatingExceptionRetryPolicy.php
@@ -32,7 +32,12 @@ class NonRepeatingExceptionRetryPolicy implements RetryPolicy
      */
     public function shouldRetry(Exception $e, RetryContext $context): bool
     {
-        $lastException = $context->getLastException();
+        $lastException = null;
+        $exceptionCount = $context->getExceptionCount();
+
+        if ($exceptionCount > 1) {
+            $lastException = $context->getExceptions()[$exceptionCount - 1];
+        }
 
         // If there was no previous exception or the previous exception is of a different type, retry.
         if ($lastException === null || get_class($lastException) !== get_class($e)) {

--- a/src/RetryTemplate.php
+++ b/src/RetryTemplate.php
@@ -189,7 +189,7 @@ class RetryTemplate implements RetryTemplateInterface
         ]);
 
         $context->incrementRetryCount();
-        $context->setLastException($e);
+        $context->addException($e);
     }
 
     /**

--- a/tests/Context/RetryContextTest.php
+++ b/tests/Context/RetryContextTest.php
@@ -14,7 +14,8 @@ class RetryContextTest extends TestCase
 
         // Test initial state.
         $this->assertEquals(0, $context->getRetryCount());
-        $this->assertNull($context->getLastException());
+        $this->assertEmpty($context->getExceptions());
+        $this->assertEquals(0, $context->getExceptionCount());
 
         // Test incrementing retry count.
         $context->incrementRetryCount();
@@ -23,8 +24,9 @@ class RetryContextTest extends TestCase
 
         // Test setting and getting last exception.
         $exception = new Exception('Test exception');
-        $context->setLastException($exception);
-        $this->assertSame($exception, $context->getLastException());
+        $context->addException($exception);
+        $this->assertSame([$exception], $context->getExceptions());
+        $this->assertEquals(1, $context->getExceptionCount());
 
         // Test getting start time.
         $this->assertIsFloat($context->getStartTime());

--- a/tests/Policy/Retry/NonRepeatingExceptionRetryPolicyTest.php
+++ b/tests/Policy/Retry/NonRepeatingExceptionRetryPolicyTest.php
@@ -17,7 +17,13 @@ class NonRepeatingExceptionRetryPolicyTest extends TestCase
         $exception3 = new Exception("Exception 3");
 
         $context = $this->createMock(RetryContext::class);
-        $context->method('getLastException')->willReturnOnConsecutiveCalls(null, $exception1, $exception2, $exception3);
+        $context->method('getExceptions')->willReturnOnConsecutiveCalls(
+            // Assert when getExceptionCount() == 1, getExceptions() is not called
+            [$exception1, $exception1],
+            [$exception1, $exception1, $exception2],
+            [$exception1, $exception2, $exception3, $exception3]
+        );
+        $context->method('getExceptionCount')->willReturnOnConsecutiveCalls(1, 2, 3, 4);
 
         $retryPolicy = new NonRepeatingExceptionRetryPolicy();
 

--- a/tests/RetryTemplateTest.php
+++ b/tests/RetryTemplateTest.php
@@ -201,7 +201,7 @@ class RetryTemplateTest extends TestCase
             ->method('recover')
             ->will($this->returnCallback(function (RetryContext $context) use ($exception) {
                 // Assert that the RetryContext has the correct exception
-                $this->assertEquals($exception, $context->getLastException());
+                $this->assertEquals($exception, $context->getExceptions()[$context->getExceptionCount() - 1]);
                 return 'Recovered';
             }));
 


### PR DESCRIPTION
### Description of Changes

This PR addresses a bug in `NonRepeatingRetryPolicy` where the action was not being retried as expected when different exceptions were thrown. The root of the issue was that `RetryContext` was storing only the last exception, which was set before checking if the current exception was different from the last one. 

To resolve this, the `RetryContext` has been changed to store all exceptions that occurred during execution. Now, `NonRepeatingRetryPolicy` can retrieve the list of exceptions and identify if the current exception has occurred before.

### Related Issue

This PR resolves the issue described here: #12 

### How Has This Been Tested?

The changes have been tested by:
1. Instantiating a `NonRepeatingRetryPolicy`.
2. Executing a failing operation that throws different exceptions in each attempt.
3. Observing that the operation retries when the exceptions are different.

In addition, existing unit tests have been adjusted to account for this change and all tests pass successfully.

### Checklist
- [x] I have tested my changes and corrected any errors.
- [x] I have documented my changes if necessary.
