### PR TITLE
Add Default Values to Retry Policies

### DIFF
--- a/src/Policy/Retry/MaxAttemptsRetryPolicy.php
+++ b/src/Policy/Retry/MaxAttemptsRetryPolicy.php
@@ -31,7 +31,7 @@ class MaxAttemptsRetryPolicy implements RetryPolicy
      *
      * @param int $maxAttempts The maximum number of retry attempts.
      */
-    public function __construct(int $maxAttempts)
+    public function __construct(int $maxAttempts = 3)
     {
         $this->maxAttempts = $maxAttempts;
     }

--- a/src/Policy/Retry/TimeoutRetryPolicy.php
+++ b/src/Policy/Retry/TimeoutRetryPolicy.php
@@ -26,7 +26,7 @@ class TimeoutRetryPolicy implements RetryPolicy
      * @param int $timeoutMilliseconds The timeout in milliseconds after which
      *                                 no more retries should be attempted.
      */
-    public function __construct(int $timeoutMilliseconds)
+    public function __construct(int $timeoutMilliseconds = 30000)
     {
         $this->timeoutMilliseconds = $timeoutMilliseconds;
     }

--- a/src/RetryTemplate.php
+++ b/src/RetryTemplate.php
@@ -34,11 +34,6 @@ use Psr\Log\LoggerInterface;
  */
 class RetryTemplate implements RetryTemplateInterface
 {
-    /**
-     * The default maximum number of retry attempts.
-     */
-    public const DEFAULT_MAX_ATTEMPTS = 3;
-
     private RetryPolicy $retryPolicy;
     private BackoffPolicy $backoffPolicy;
     private RetryStatistics $retryStatistics;
@@ -52,7 +47,7 @@ class RetryTemplate implements RetryTemplateInterface
         Sleeper $sleeper = null,
         LoggerInterface $logger = null
     ) {
-        $this->retryPolicy = $retryPolicy ?: new MaxAttemptsRetryPolicy(self::DEFAULT_MAX_ATTEMPTS);
+        $this->retryPolicy = $retryPolicy ?: new MaxAttemptsRetryPolicy();
         $this->backoffPolicy = $backoffPolicy ?: new FixedBackoffPolicy();
         $this->retryStatistics = $retryStatistics ?: new InMemoryRetryStatistics();
         $this->sleeper = $sleeper ?: new NanoSleeper();

--- a/tests/Policy/Retry/MaxAttemptsRetryPolicyTest.php
+++ b/tests/Policy/Retry/MaxAttemptsRetryPolicyTest.php
@@ -16,8 +16,7 @@ class MaxAttemptsRetryPolicyTest extends TestCase
         $retryContext = $this->createMock(RetryContext::class);
         $retryContext->method('getRetryCount')->willReturnOnConsecutiveCalls(1, 2, 3, 4, 5);
 
-        $maxAttempts = 3;
-        $retryPolicy = new MaxAttemptsRetryPolicy($maxAttempts);
+        $retryPolicy = new MaxAttemptsRetryPolicy();
 
         // Should retry until the number of attempts reaches the maximum limit
         $this->assertTrue($retryPolicy->shouldRetry($exception, $retryContext));

--- a/tests/Policy/Retry/TimeoutRetryPolicyTest.php
+++ b/tests/Policy/Retry/TimeoutRetryPolicyTest.php
@@ -17,7 +17,7 @@ class TimeoutRetryPolicyTest extends TestCase
         $context->method('getStartTime')
             ->willReturn(microtime(true) - 0.5);  // 500 milliseconds ago
 
-        $retryPolicy = new TimeoutRetryPolicy(1000);  // 1000 milliseconds timeout
+        $retryPolicy = new TimeoutRetryPolicy();  // 30000 milliseconds timeout
 
         // The operation should be retried, as the elapsed time is less than the timeout.
         $this->assertTrue($retryPolicy->shouldRetry($exception, $context));
@@ -29,9 +29,9 @@ class TimeoutRetryPolicyTest extends TestCase
         $context = $this->createMock(RetryContext::class);
 
         $context->method('getStartTime')
-            ->willReturn(microtime(true) - 1.5);  // 1500 milliseconds ago
+            ->willReturn(microtime(true) - 30.5);  // 30500 milliseconds ago
 
-        $retryPolicy = new TimeoutRetryPolicy(1000);  // 1000 milliseconds timeout
+        $retryPolicy = new TimeoutRetryPolicy();  // 30000 milliseconds timeout
 
         // The operation should not be retried, as the elapsed time is greater than the timeout.
         $this->assertFalse($retryPolicy->shouldRetry($exception, $context));
@@ -44,9 +44,9 @@ class TimeoutRetryPolicyTest extends TestCase
 
         // 999 milliseconds ago
         $context->method('getStartTime')
-            ->willReturn(microtime(true) - 0.999);
+            ->willReturn(microtime(true) - 29.999); // 29999.9 milliseconds ago
 
-        $retryPolicy = new TimeoutRetryPolicy(1000);  // 1000 milliseconds timeout
+        $retryPolicy = new TimeoutRetryPolicy();  // 30000 milliseconds timeout
 
         // The operation should be retried, as the elapsed time is just before the timeout.
         $this->assertTrue($retryPolicy->shouldRetry($exception, $context));
@@ -59,9 +59,9 @@ class TimeoutRetryPolicyTest extends TestCase
 
         // 1001 milliseconds ago
         $context->method('getStartTime')
-            ->willReturn(microtime(true) - 1.001);
+            ->willReturn(microtime(true) - 30.001);
 
-        $retryPolicy = new TimeoutRetryPolicy(1000);  // 1000 milliseconds timeout
+        $retryPolicy = new TimeoutRetryPolicy();  // 30000 milliseconds timeout
 
         // The operation should not be retried, as the elapsed time is just after the timeout.
         $this->assertFalse($retryPolicy->shouldRetry($exception, $context));
@@ -74,9 +74,9 @@ class TimeoutRetryPolicyTest extends TestCase
 
         // exactly 1000 milliseconds ago
         $context->method('getStartTime')
-            ->willReturn(microtime(true) - 1.0);
+            ->willReturn(microtime(true) - 30.0);
 
-        $retryPolicy = new TimeoutRetryPolicy(1000);  // 1000 milliseconds timeout
+        $retryPolicy = new TimeoutRetryPolicy();  // 30000 milliseconds timeout
 
         // The operation should not be retried, as the elapsed time is exactly at the timeout.
         $this->assertFalse($retryPolicy->shouldRetry($exception, $context));


### PR DESCRIPTION
### Description of Changes

This PR introduces default values for `MaxAttemptsRetryPolicy` and `TimeoutRetryPolicy` in the RetryMaster library. Prior to this, these classes did not have default values, unlike the other policies in the library. 

The introduction of default values provides consistency across different policy classes in the library and helps prevent unexpected behavior or failure to instantiate these classes when arguments are not provided.

### Related Issue

This PR resolves the issue described here: #13 

### How Has This Been Tested?

The changes have been tested by:
1. Instantiating `MaxAttemptsRetryPolicy` and `TimeoutRetryPolicy` without providing any arguments.
2. Verifying that these classes are successfully instantiated with reasonable default values.

In addition, existing unit tests have been adjusted to account for this change and all tests pass successfully.

### Checklist

- [x] I have tested my changes and corrected any errors.
- [x] I have documented my changes if necessary.
