### PR TITLE
Non Repeating Exception Policy - Fix Last Exception Offset

### DIFF
--- a/src/Policy/Retry/NonRepeatingExceptionRetryPolicy.php
+++ b/src/Policy/Retry/NonRepeatingExceptionRetryPolicy.php
@@ -36,7 +36,7 @@ class NonRepeatingExceptionRetryPolicy implements RetryPolicy
         $exceptionCount = $context->getExceptionCount();
 
         if ($exceptionCount > 1) {
-            $lastException = $context->getExceptions()[$exceptionCount - 1];
+            $lastException = $context->getExceptions()[$exceptionCount - 2];
         }
 
         // If there was no previous exception or the previous exception is of a different type, retry.

--- a/tests/Policy/Retry/NonRepeatingExceptionRetryPolicyTest.php
+++ b/tests/Policy/Retry/NonRepeatingExceptionRetryPolicyTest.php
@@ -20,8 +20,8 @@ class NonRepeatingExceptionRetryPolicyTest extends TestCase
         $context->method('getExceptions')->willReturnOnConsecutiveCalls(
             // Assert when getExceptionCount() == 1, getExceptions() is not called
             [$exception1, $exception1],
-            [$exception1, $exception1, $exception2],
-            [$exception1, $exception2, $exception3, $exception3]
+            [$exception1, $exception2, $exception1],
+            [$exception1, $exception2, $exception3, $exception1]
         );
         $context->method('getExceptionCount')->willReturnOnConsecutiveCalls(1, 2, 3, 4);
 


### PR DESCRIPTION
### Description of Changes

This PR addresses a bug in `NonRepeatingRetryPolicy` where the action was not being retried as expected when different exceptions were thrown.

### Related Issue

This PR resolves the issue described here: #12. Pull Request #16 didn't solve the issue.

### How Has This Been Tested?

The changes have been tested by:
1. Instantiating a `NonRepeatingRetryPolicy`.
2. Executing a failing operation that throws different exceptions in each attempt.
3. Observing that the operation retries when the exceptions are different.

In addition, existing unit tests have been adjusted to account for this change and all tests pass successfully.

### Checklist
- [x] I have tested my changes and corrected any errors.
- [x] I have documented my changes if necessary.
